### PR TITLE
Don't install a specific bundler version (2.1.4) in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,3 @@ notifications:
   email:
     on_success: never
     on_failure: always
-before_install: gem install bundler -v 2.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Added
 - Prevent mutating a returned `result` from outside of the action
 
+### Maintenance
+- Don't install a specific `bundler` version in Travis
+
 ## 0.2.1 - 2020-06-15
 ### Added
 - Raise an explicit error if action class fails to implement #execute

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
-    amazing_print (1.2.0)
+    amazing_print (1.2.1)
     ast (2.4.1)
     builder (3.2.4)
     byebug (11.1.3)
@@ -224,4 +224,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.1.4
+   2.1.2


### PR DESCRIPTION
Bundler 2.1.2 is pre-installed on Travis, so I have regenerated `Gemfile.lock` using `bundler` 2.1.2 ; this should avoid any warning being printed about a mismatch between the Travis bundler version and the bundler version that generated the `Gemfile.lock`.