### PR TITLE
Run tests on Travis via `bin/rspec` command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ notifications:
   email:
     on_success: never
     on_failure: always
+script:
+  - bin/rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Maintenance
 - Don't install a specific `bundler` version in Travis
+- Run tests on Travis via `bin/rspec` (rather than (implicitly) via `bundle exec rake`)
 
 ## 0.2.1 - 2020-06-15
 ### Added


### PR DESCRIPTION
On my local machine, the `bin/rspec` command is a little faster than the Travis default of `bundle exec rake` (~3.8 seconds vs ~4.8 seconds).