### PR TITLE
Add `::new!` and `::run!` class methods for actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
-[no unreleased changes yet]
+### BREAKING CHANGES
+- Change the behavior of the `#run!` instance method to also raise an error if any failure
+  conditions (i.e. failures set via a `fails_with` case) occur during the execution of the action.
+  (Previously, `#run!` would only raise if any of the initialization params were invalid.)
+
+### Added
+- Add `::new!` and `::run!` class methods for actions
 
 ## v0.14.2 (2021-01-26)
 ### Dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GIT
 PATH
   remote: .
   specs:
-    active_actions (0.14.3.alpha)
+    active_actions (0.15.0.alpha)
       memoist (~> 0.16)
       rails (~> 6.0)
       shaped (~> 0.7.0)

--- a/lib/active_actions.rb
+++ b/lib/active_actions.rb
@@ -16,4 +16,5 @@ class ActiveActions::InvalidParam < ActiveActions::Error ; end
 class ActiveActions::MissingParam < ActiveActions::Error ; end
 class ActiveActions::MissingResultValue < ActiveActions::Error ; end
 class ActiveActions::MutatingLockedResult < ActiveActions::Error ; end
+class ActiveActions::RuntimeFailure < ActiveActions::Error ; end
 class ActiveActions::TypeMismatch < ActiveActions::Error ; end

--- a/lib/active_actions/version.rb
+++ b/lib/active_actions/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveActions
-  VERSION = '0.14.3.alpha'
+  VERSION = '0.15.0.alpha'
 end

--- a/spec/active_actions/base_spec.rb
+++ b/spec/active_actions/base_spec.rb
@@ -61,6 +61,42 @@ RSpec.describe ActiveActions::Base do
   let(:params) { { user: user, number_of_widgets: 32 } }
   let(:user) { User.new(email: 'davidjrunger@gmail.com', phone: '15551239876') }
 
+  describe '::run!' do
+    subject(:run!) { DoubleNumber.run!(number: 8) }
+
+    let(:double_number_action_double) { instance_double(DoubleNumber) }
+
+    it 'calls the ::new! class method and the #run! instance method' do
+      expect(DoubleNumber).to receive(:new!).and_return(double_number_action_double)
+      expect(double_number_action_double).to receive(:run!)
+
+      run!
+    end
+  end
+
+  describe '::new!' do
+    subject(:new!) { ProcessOrder.new!(number_of_widgets: 2, user: user) }
+
+    it 'calls the ::new class method' do
+      expect(ProcessOrder).to receive(:new).and_call_original
+      new!
+    end
+
+    context 'when the provided params are valid' do
+      it 'returns an action instance' do
+        expect(new!).to be_a(ProcessOrder)
+      end
+    end
+
+    context 'when the provided params are not valid' do
+      before { user.email = 'not an email' }
+
+      it 'raises an ActiveActions::InvalidParam error' do
+        expect { new! }.to raise_error(ActiveActions::InvalidParam)
+      end
+    end
+  end
+
   describe '::requires' do
     def initialize_action(params)
       action_klass.new(params)


### PR DESCRIPTION
Also: change the behavior of the `#run!` instance method to no longer check for valid params (which should now be done via `::new!` instead) and to start checking for an absence of failure conditions.