### PR TITLE
Remove claim in README.md that `shaped` must be listed in `Gemfile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
-[no unreleased changes yet]
+### Fixed
+- Remove no-longe-accurate claim in README.md that `shaped` must be listed in apps' `Gemfile`s
 
 ## v0.17.0 (2021-02-17)
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,13 +57,6 @@ need to install it from GitHub.
 gem 'active_actions', git: 'https://github.com/davidrunger/active_actions.git'
 ```
 
-You'll also need to list one of `active_actions`'s dependencies,
-[`shaped`](https://github.com/davidrunger/shaped/), in your `Gemfile`, too:
-
-```rb
-gem 'shaped', git: 'https://github.com/davidrunger/shaped.git'
-```
-
 And then execute:
 
 ```


### PR DESCRIPTION
(This is no longer true, now that `shaped` is released via RubyGems rather than via GitHub.)