### PR TITLE
Don't execute `Bundler.require`

### DIFF
--- a/lib/active_actions.rb
+++ b/lib/active_actions.rb
@@ -2,8 +2,6 @@
 
 module ActiveActions ; end
 
-require 'bundler'
-Bundler.require
 require 'active_support/all'
 require 'active_model'
 require 'active_record'


### PR DESCRIPTION
This was making this gem really slow to require (according to [`bumbler`][1])!

[1]: https://github.com/nevir/Bumbler