### PR TITLE
Explicitly define an `ActiveActions::Generators` module

### DIFF
--- a/lib/generators/active_actions/action/action_generator.rb
+++ b/lib/generators/active_actions/action/action_generator.rb
@@ -2,6 +2,8 @@
 
 require 'rails/generators'
 
+module ActiveActions::Generators ; end
+
 class ActiveActions::Generators::ActionGenerator < ::Rails::Generators::NamedBase
   source_root File.expand_path('templates', __dir__)
 


### PR DESCRIPTION
Without this, attempting to run the generator was generating an error about the constant `ActiveActions::Generators` being undefined.