### PR TITLE
Add Ruby version number to Gemfile (and Gemfile.lock)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
+ruby '3.1.3'
 
 # Specify your gem's dependencies in active_actions.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,5 +255,8 @@ DEPENDENCIES
   runger_style!
   sqlite3
 
+RUBY VERSION
+   ruby 3.1.3p185
+
 BUNDLED WITH
    2.2.22


### PR DESCRIPTION
Dependabot failed to update dependencies at least once (https://github.com/davidrunger/active_actions/security/dependabot/16/update-logs/298775114). It's not clear to me what caused that error ("Dependabot::Bundler::FileUpdater::RubyRequirementSetter::RubyVersionNotFound") or how to fix it, but I'm hoping that this change might help.